### PR TITLE
Setup Scala.js project scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+target/
+project/target/
+project/project/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# oracle-switcher
+# Oracle Switcher
+
+This project uses **Scala 3** with **Scala.js** to target the browser.
+
+## Build
+
+Use [sbt](https://www.scala-sbt.org/) to compile the project:
+
+```bash
+sbt fastLinkJS
+```
+
+The generated JavaScript will be found under `target/scala-3.*`. You can include it in an HTML page using a `<script type="module">` tag.
+
+## Development Notes
+
+- A `package.json` and bundler configuration can be added later if you want to manage npm dependencies or bundle assets.
+- Scala.js already outputs an ES module that can be used directly with modern browsers or further processed by tools like webpack or Vite.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,13 @@
+name := "oracle-switcher"
+
+version := "0.1.0-SNAPSHOT"
+
+scalaVersion := "3.3.1"
+
+enablePlugins(ScalaJSPlugin)
+
+scalaJSUseMainModuleInitializer := true
+
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
+
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.8.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")

--- a/src/main/scala/MainApp.scala
+++ b/src/main/scala/MainApp.scala
@@ -1,0 +1,11 @@
+package app
+
+import org.scalajs.dom
+import org.scalajs.dom.document
+
+object MainApp:
+  def main(args: Array[String]): Unit =
+    val placeholder = document.createElement("div")
+    placeholder.textContent = "Oracle Switcher Placeholder"
+    document.body.appendChild(placeholder)
+


### PR DESCRIPTION
## Summary
- initialize Scala 3 project using Scala.js plugin
- configure project for ES module output
- add minimal `MainApp` rendering placeholder text
- document build and bundler notes in README
- ignore build artifacts

## Testing
- `sbt fastLinkJS`
- `sbt clean`

------
https://chatgpt.com/codex/tasks/task_e_684684f20344832fb6ea07565fb71f5f