### PR TITLE
Add missing tarot court cards

### DIFF
--- a/src/main/resources/tarot.json
+++ b/src/main/resources/tarot.json
@@ -1,0 +1,628 @@
+{
+  "cards": [
+    {
+      "name": "The Fool",
+      "arcana": "major",
+      "suit": null,
+      "number": 0,
+      "meaningUpright": "Freeing yourself from limitation; Expressing joy and youthful vigor; Being open-minded; Taking a leap of faith; Attuning yourself to your instincts; Being eager or curious; Exploring your potential; Embracing innovation and change",
+      "meaningReversed": "Being gullible and naive; Taking unnecessary risks; Failing to be serious when required; Being silly or distracted; Lacking experience; Failing to honor well-established traditions and limits; Behaving inappropriately"
+    },
+    {
+      "name": "The Magician",
+      "arcana": "major",
+      "suit": null,
+      "number": 1,
+      "meaningUpright": "Taking appropriate action; Receiving guidance from a higher power; Becoming a channel of divine will; Expressing masculine energy in appropriate and constructive ways; Being yourself in every way",
+      "meaningReversed": "Inflating your own ego; Abusing talents; Manipulating or deceiving others; Being too aggressive; Using cheap illusions to dazzle others; Refusing to invest the time and effort needed to master your craft; Taking shortcuts"
+    },
+    {
+      "name": "The Papess/High Priestess",
+      "arcana": "major",
+      "suit": null,
+      "number": 2,
+      "meaningUpright": "Listening to your feelings and intuitions; Exploring unconventional spirituality; Keeping secrets; Being receptive; Reflecting instead of acting; Observing others; Preserving purity",
+      "meaningReversed": "Being aloof; Obsessing on secrets and conspiracies; Rejecting guidance from spirit or intuition; Revealing all; Ignoring gut feelings; Refusing to become involved, even when involvement is appropriate"
+    },
+    {
+      "name": "The Empress",
+      "arcana": "major",
+      "suit": null,
+      "number": 3,
+      "meaningUpright": "Nurturing yourself and others; Bearing fruit; Celebrating your body; Bearing (literal or figurative) children; Reveling in luxury; Mothering those around you in positive ways; Enjoying your sexuality; Getting things done",
+      "meaningReversed": "Overindulging; Being greedy; Smothering someone with attention; Debilitating someone by being overprotective; Inhibiting productivity by obsessing on productivity; Being overcome by addictive behavior"
+    },
+    {
+      "name": "The Emperor",
+      "arcana": "major",
+      "suit": null,
+      "number": 4,
+      "meaningUpright": "Exercising authority; Defining limits; Directing the flow of work; Communicating clear guidelines; Being in control of yourself and others; Tempering aggressive masculinity with wisdom and experience",
+      "meaningReversed": "Micromanaging; Crushing the creativity of others with a rigid, iron-fisted approach; Insisting on getting your own way; Assuming a dictatorial mindset; Using overt force to achieve your goals and maintain order"
+    },
+    {
+      "name": "The Pope/Hierophant",
+      "arcana": "major",
+      "suit": null,
+      "number": 5,
+      "meaningUpright": "Teaching or guiding others; Searching for the truth; Asking for guidance from a higher power; Acknowledging the wisdom and experience of others; Taking vows; Engaging in heartfelt rituals; Volunteering",
+      "meaningReversed": "Using experience as a means of manipulating or misguiding others; Being dogmatic; Favoring tradition over what is expedient or necessary; Going through the motions of empty rituals; Concealing wisdom; Restricting access to spiritual truths or the gods"
+    },
+    {
+      "name": "The Lovers",
+      "arcana": "major",
+      "suit": null,
+      "number": 6,
+      "meaningUpright": "Being in love; Showing your love to others; Expressing passion or romantic feelings; Aligning yourself with groups or like-minded others; Bringing people together; Making well-informed decisions",
+      "meaningReversed": "Debilitating passion; Allowing an unhealthy desire for love to motivate destructive behavior; Disrupting unity; Working against the best interests of those who care about you; Ill-informed decisions"
+    },
+    {
+      "name": "The Chariot",
+      "arcana": "major",
+      "suit": null,
+      "number": 7,
+      "meaningUpright": "Breaking through barriers; Moving forward with confidence and authority; Reaching the pinnacle of success; Basking in the glory of achievement; Guiding an effort to total victory; Establishing yourself as a worthy leader",
+      "meaningReversed": "Resting on laurels; Riding roughshod over the feelings or expectations of others; Focusing more on past successes than future opportunities; Failing to rein in impulsive behavior"
+    },
+    {
+      "name": "Strength",
+      "arcana": "major",
+      "suit": null,
+      "number": 8,
+      "meaningUpright": "Imposing restrictions on yourself for your own benefit; Bringing your passions under the control of reason; Resisting impulses that work against your best interests; Taking bold action",
+      "meaningReversed": "Indulging weakness, even when you know it will damage your health and happiness; Languishing in addiction; Allowing your instincts to tame and conquer you; Failing to take a stand when necessary"
+    },
+    {
+      "name": "The Hermit",
+      "arcana": "major",
+      "suit": null,
+      "number": 9,
+      "meaningUpright": "Becoming or seeking out a guru; Going on a retreat; Recharging spiritual or creative batteries; Lighting the way for those with less experience; Stepping back to gain perspective",
+      "meaningReversed": "Being a loner; Fearing contact with others; Becoming a know-it-all; Inflating claims of expertise; Hiding your skills and talents out of fear of unworthiness"
+    },
+    {
+      "name": "The Wheel",
+      "arcana": "major",
+      "suit": null,
+      "number": 10,
+      "meaningUpright": "Allowing events to unfold; Seeing the larger pattern in everyday events; Trusting your luck; Watching for cycles; Believing that \"what goes around, comes around\"",
+      "meaningReversed": "Losing money gambling; Refusing to do your part to bring a plan to fruition; Taking a fatalistic approach to life; Fighting the natural course of events"
+    },
+    {
+      "name": "Justice",
+      "arcana": "major",
+      "suit": null,
+      "number": 11,
+      "meaningUpright": "Making an objective decision; Weighing an issue carefully before taking action; Appropriately scaling your reaction to a situation; Getting all the facts; Considering evidence; Deliberating",
+      "meaningReversed": "Delivering harsh criticism; Obsessing on rules and regulations; Playing by the book even when it is destructive or counterproductive to do so; Confusing snap decisions with timely action; Playing favorites"
+    },
+    {
+      "name": "The Hanged Man",
+      "arcana": "major",
+      "suit": null,
+      "number": 12,
+      "meaningUpright": "Seeing growth opportunities in unpleasant events; Experiencing a dramatic change in personal perspective; Making the best of an unforeseen change in your life or work; Suspending disbelief; Making sacrifices",
+      "meaningReversed": "Being untrue to yourself and your values; Refusing to make sacrifices when appropriate; Refusing to adapt to new situations; Blaming others; Profiting at the expense of others"
+    },
+    {
+      "name": "Death",
+      "arcana": "major",
+      "suit": null,
+      "number": 13,
+      "meaningUpright": "Bringing an unpleasant phase of life to an end; Recognizing and celebrating the conclusion of something; Putting bad habits to rest; Becoming a new person; Leaving one person, place, or thing for another; Letting go",
+      "meaningReversed": "Obsessing on death and dying; Refusing to give up old habits or unhealthy relationships; Insisting that everything and everyone should stay the same forever; Failing to take good care of yourself"
+    },
+    {
+      "name": "Temperance",
+      "arcana": "major",
+      "suit": null,
+      "number": 14,
+      "meaningUpright": "Bringing opposites together; Moderating your actions or emotions; Finding middle ground; Reaching compromises; Synthesizing solutions that please everyone involved; Using the old to make something new",
+      "meaningReversed": "Going to extremes; Disrupting group efforts; Ignoring healthy approaches to life; Becoming an addict; Practicing gluttony; Tearing something or someone apart; Breaking alliances"
+    },
+    {
+      "name": "The Devil",
+      "arcana": "major",
+      "suit": null,
+      "number": 15,
+      "meaningUpright": "Appreciating the luxuries that life has to offer; Being comfortable in your own skin; Enjoying your sexuality; Splurging on an expensive personal item; Embracing the fact that everyone has a darker side; Dealing with unhealthy impulses in healthy ways",
+      "meaningReversed": "Putting excessive emphasis on appearances; Always wanting more; Valuing possessions more than people or relationships; Allowing base instincts to govern your life; Being selfish; Attributing your own dark impulses to outside forces or other people"
+    },
+    {
+      "name": "The Tower",
+      "arcana": "major",
+      "suit": null,
+      "number": 16,
+      "meaningUpright": "Breaking out of old, confining habits and mindsets; Clearing the way for new growth; Dispelling the influence of an inflated ego; Getting back to basics; Stripping away harmful illusions; Receiving sudden insight",
+      "meaningReversed": "Clinging to traditions that repress growth; Engaging in willful blindness; Rejecting evidence that change is needed; Ignoring guidance from a higher power; Maliciously engaging in destructive behavior"
+    },
+    {
+      "name": "The Star",
+      "arcana": "major",
+      "suit": null,
+      "number": 17,
+      "meaningUpright": "Hoping for the best; Believing good things happen to good people; Seeing events in the best possible light; Adopting a generous spirit; Seeking guidance from above; Embracing possibility over probability",
+      "meaningReversed": "Denying unpleasant truths; Denying personal accountability and saying, \"Things just happen!\"; Ignoring signs and omens; Preferring illusion to reality; Spreading pessimism and stinginess of spirit"
+    },
+    {
+      "name": "The Moon",
+      "arcana": "major",
+      "suit": null,
+      "number": 18,
+      "meaningUpright": "Enjoying healthy fantasies and daydreams; Using your imagination; Practicing magic or celebrating the magic of everyday life; Attuning yourself to the cycles of nature; Embracing the unknown",
+      "meaningReversed": "Becoming unable to separate fantasy from reality; Suffering from delusions; Losing your appreciation for the fantastic or magical; Adopting a ruthlessly logical mindset; Failing to appreciate life's mysteries"
+    },
+    {
+      "name": "The Sun",
+      "arcana": "major",
+      "suit": null,
+      "number": 19,
+      "meaningUpright": "Seeing things clearly; Experiencing intense joy; Celebrating your own successes; Knowing you're good at what you do; Gaining recognition for your personal genius",
+      "meaningReversed": "Being dazzled by your own accomplishments; Becoming absorbed in your own self-image; Feeling rushed and distracted; Exerting yourself to the point of exhaustion; Overstating your abilities or misrepresenting your achievements"
+    },
+    {
+      "name": "Judgement",
+      "arcana": "major",
+      "suit": null,
+      "number": 20,
+      "meaningUpright": "Receiving a wake-up call; Discovering a new purpose in life; Becoming totally and completely yourself; Receiving a well-deserved reward; Passing an evaluation or examination; Welcoming the start of a new phase of life",
+      "meaningReversed": "Being weighed in the balances and found wanting; Failing to measure up to a well-defined standard; Being caught goofing off or misbehaving; Failing to prepare for an examination you know is coming; Rejecting an opportunity to reinvent yourself"
+    },
+    {
+      "name": "The World",
+      "arcana": "major",
+      "suit": null,
+      "number": 21,
+      "meaningUpright": "Having it all; Knowing and loving yourself as completely as possible; Seeing the interconnection of all things and people; Enhancing your perspective; Living life to its fullest; Understanding the meaning of life",
+      "meaningReversed": "Allowing greed and envy to prevent you from enjoying what you do possess; Failing to see the larger design in ordinary events; Believing that everything that exists can be touched, counted, or measured; Failing to see the divine reflected in those around you"
+    },
+    {
+      "name": "ace of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 1,
+      "meaningUpright": "Being inspired; Identifying an important goal; Being given the opportunity to do whatever you want to do; Giving or receiving direction; Seeing a solution; Creating something new; Being aroused, sexually or creatively",
+      "meaningReversed": "Failing to take advantage of a great opportunity; Being ineffectual or lazy; Making an inadequate effort; Working toward a goal, but lacking the resources or initiative to achieve success; Setting inappropriate goals; Failing to take a stand"
+    },
+    {
+      "name": "two of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 2,
+      "meaningUpright": "Having a choice; Offering or being offered an option; Seeing the value of another person's approach; Understanding there's more than one way to \"skin a cat\"; Successfully doing more than one thing at a time; Being empowered to make a choice",
+      "meaningReversed": "Misrepresenting your intentions; Doing one thing while desiring another; Changing course mid-stream for no good reason; Refusing to change your goal even when pursuing it no longer makes sense; Disregarding the input of others"
+    },
+    {
+      "name": "three of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 3,
+      "meaningUpright": "Putting a plan into motion; Taking that critical first step; Making good things happen; Going beyond your limits; Blazing new trails; Hitting the ground running; Seeing your plans come to fruition",
+      "meaningReversed": "Procrastinating; Knowing what to do, but refusing to do it; Launching a project without a clear definition of who should do what; Rejecting an opportunity to try something new; Failing to finish what you start"
+    },
+    {
+      "name": "four of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 4,
+      "meaningUpright": "Sharing in a great celebration; Sharing in a communal sense of achievement and success; Preparing for a party; Working together toward a common goal; Giving or winning awards",
+      "meaningReversed": "Keeping your nose to the grindstone; Recognizing good work by demanding more work; Failing to share in a group celebration; Allowing sour grapes to poison your moment in the sun; Refusing to do your part"
+    },
+    {
+      "name": "five of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 5,
+      "meaningUpright": "Calmly expressing a dissenting opinion; Allowing someone to use his or her own methods to get a job done; Opening the floor for discussion or debate; Comparing progress made so far to standards set earlier",
+      "meaningReversed": "Berating others for their ridiculous opinions; Picking fights; Offering destructive criticism; Baiting people with barbed remarks; Disrupting progress with an endless stream of pointless objections"
+    },
+    {
+      "name": "six of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 6,
+      "meaningUpright": "Outperforming your peers; Winning a competition; Being recognized as a capable person; Having your \"moment in the spotlight\"; Being cheered on by the crowd; Getting an award; Earning the admiration of others; Telling someone, \"Good job!\"",
+      "meaningReversed": "Being a bad winner; Allowing your achievements to inflate your ego; Looking down on people who seem less capable; Craving to be the center of attention; Giving or receiving insincere praise; Envying the achievements of others"
+    },
+    {
+      "name": "seven of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 7,
+      "meaningUpright": "Refusing to be silenced through fear or intimidation; Continuing a fight against all odds; Being fierce; Defending yourself against physical and emotional attacks; Refusing to put up with abuse; Clinging to your values despite all pressure to abandon them",
+      "meaningReversed": "Having a chip on your shoulder; Taking unnecessary risks as a means of proving your fearlessness; Looking for an opportunity to take offense; Responding to constructive criticism with defensiveness; Refusing to stand up for yourself and your beliefs"
+    },
+    {
+      "name": "eight of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 8,
+      "meaningUpright": "Taking swift action; Moving forward with a plan as quickly as possible; Energizing yourself; Adapting to sudden changes; Taking setbacks in stride; Embracing the idea that nothing stays the same forever; Reacting quickly and appropriately to unforeseen problems",
+      "meaningReversed": "Giving in to panic; Running in circles and screaming; Insisting things must always stay the same; Stirring the pot just to see what will happen; Rushing others; Refusing to re-evaluate a schedule or program, even when it's clearly no longer appropriate"
+    },
+    {
+      "name": "nine of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 9,
+      "meaningUpright": "Sticking with it for the duration; Fulfilling your promises and obligations; Bearing up under incredible duress; Dragging yourself across the finish line; Picking yourself up by your own bootstraps; Refusing to quit; Going as far as you can go and being satisfied with your performance",
+      "meaningReversed": "Making yourself a martyr; Abandoning your post; Giving up at the first sign of opposition; Being prevented from fulfilling an obligation; Failing to be dependable; Refusing to let something go that needs to be released; Beating a dead horse"
+    },
+    {
+      "name": "ten of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 10,
+      "meaningUpright": "Holding your own in extreme circumstances; Helping others carry their burdens; Coming to the aid of the oppressed; Knowing and being honest about your own limits; Recognizing when you are not well-suited for a particular task",
+      "meaningReversed": "Taking on more work than you know you can handle; Refusing to say \"No\" when you're already overloaded; Making a habit of working overtime; Shielding others from facing the consequences of their own poor judgment; Over-extending yourself on a regular basis"
+    },
+    {
+      "name": "page of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 11,
+      "meaningUpright": "Leaping at a new opportunity; Being a cheerleader or ardent advocate for your cause; Being a True Believer; Taking first steps toward independence; Trusting in your own abilities; Asking for feedback",
+      "meaningReversed": "Basing your entire self-image on what others think; Seizing every new idea that comes your way without question; Habitually discounting input or feedback from others; Being so eager to \"do it yourself\" that you hinder your own progress"
+    },
+    {
+      "name": "knight of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 12,
+      "meaningUpright": "Charging ahead; Making rapid progress; Refusing limits; Dazzling those around you with your wit and charm; Convincing others of your right to leadership; Convincing others to follow you; Being a catalyst for change",
+      "meaningReversed": "Blundering forward with inadequate skill or information; Running roughshod over the feelings of others; Using sex appeal to manipulate others; Forcing your leadership or ideology on others; Beginning many projects without finishing any"
+    },
+    {
+      "name": "queen of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 13,
+      "meaningUpright": "Paying close attention; Helping others focus on the issue at hand; Getting everyone to work together; Identifying common ground; Bringing people together, despite their differences; Using reverse psychology",
+      "meaningReversed": "Being distracted, or using your charms or skills to distract others from the goal; Calling attention to yourself with negative or unhealthy behaviors; Disrupting group activities as a means of feeding your own ego"
+    },
+    {
+      "name": "king of wands",
+      "arcana": "minor",
+      "suit": "wands",
+      "number": 14,
+      "meaningUpright": "Putting old things together in new and exciting ways; Coming up with unexpected solutions; Using your experience to solve puzzles and problems; Doing what you set out to do; Directing the efforts of others",
+      "meaningReversed": "Using your creativity to get out of honest work; Investing great energy in avoiding responsibility; Boasting about achievements without putting your expertise to practical use; Lording it over others"
+    },
+    {
+      "name": "ace of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 1,
+      "meaningUpright": "Trusting your feelings; Opening yourself to spirit; Accepting and returning affection; Getting in touch with what motivates you; Taking advantage of an opportunity to express love to others; Listening to the still, small voice",
+      "meaningReversed": "Hiding your feelings; Spurning an opportunity to love or be loved; Numbing yourself to spiritual yearnings; Rejecting the counsel of your heart; Becoming a puppet of your own emotions; Indulging in hysteria or obsession"
+    },
+    {
+      "name": "two of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 2,
+      "meaningUpright": "Being drawn to someone; Longing for someone or something; Acting on your desires; Discovering a feeling is mutual; Doing what makes you feel good; Merging; Healing broken ties; Admitting two people feel differently about each other and moving on",
+      "meaningReversed": "Burning bridges; Becoming caught up in unhealthy codependency; Shutting out anyone but your chosen few; Obsessing on someone who does not return your affections; Despairing over finding \"The One\"; Deceiving yourself about your true orientation"
+    },
+    {
+      "name": "three of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 3,
+      "meaningUpright": "Celebrating your feelings or connections with others; Expressing joy through song, dance, or physical affection; Working together with others who share your feelings; Performing acts of service as a way of saying, \"I love you\"; Embracing unconventional romantic arrangements",
+      "meaningReversed": "Mistaking giddiness for true affection; Being dominated by manic emotions; Expecting everyone to always feel the same way you do; Demanding unreasonable support from friends or family; Partying to a dangerous or unhealthy extent"
+    },
+    {
+      "name": "four of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 4,
+      "meaningUpright": "Maintaining your emotional stability; Refusing to give in to overwhelming emotions; Appreciating what you have and refusing to take it for granted; Seeing the value of long-term commitments",
+      "meaningReversed": "Being bored; Daydreaming at the expense of your work; Refusing to be engaged by opportunity; Taking people and relationships for granted; Ignoring romantic or spiritual opportunities; Spurning inspiration; Feeling everything should stay \"just like it is\""
+    },
+    {
+      "name": "five of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 5,
+      "meaningUpright": "Acknowledging loss and moving on; Focusing on how the glass remains \"half-full\"; Finding the silver lining in a dark cloud; Recognizing that loss is a natural part of life; Embracing healthy grief; Learning lessons from harsh consequences",
+      "meaningReversed": "Wallowing in unhealthy grief or self-pity; Refusing to move on and let go; Clinging to the past; Obsessing on past lives and past loves; Failing to live in the present; Beating yourself up over past mistakes; Allowing fear of failure to limit your efforts"
+    },
+    {
+      "name": "six of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 6,
+      "meaningUpright": "Donating your time and talents to others; Taking satisfaction in knowing how your efforts will aid others; Creating a \"win-win\" scenario; Giving even when you know repayment is not possible; Being motivated to do a good deed",
+      "meaningReversed": "Linking your sense of self-worth to the appraisals of others; Striving to appear more needy than you really are; Taking undeserved or unmerited charity; Bragging about your charitable efforts; Profiteering in times of distress; Refusing to share a burden"
+    },
+    {
+      "name": "seven of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 7,
+      "meaningUpright": "Motivating yourself with images of future success; Using visualization to encourage progress; Taking an imaginative or creative approach to problem solving; Making dreams come true; Gleaning insight from personal visions",
+      "meaningReversed": "Obsessing on imaginary fears or uncertain consequences; Giving in to emotional or political terrorism; Spending more time dreaming than working; Failing to envision the possible repercussions of your choices; Being controlled by fear"
+    },
+    {
+      "name": "eight of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 8,
+      "meaningUpright": "Wanting something better; Blazing your own trail; Realizing there must be more to life; Leaving an unhealthy situation behind; Starting your own business; Going on a retreat; Seeking the \"still, small voice\"",
+      "meaningReversed": "Being implacable; Finding fault; Nitpicking; Refusing to settle down; Running away from problems or confrontations; Saying, \"It's my way or the highway!\"; Harping on past mistakes and disappointments; Threatening to quit as a strategy to get your way"
+    },
+    {
+      "name": "nine of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 9,
+      "meaningUpright": "Being delighted with your own achievements; Recognizing your own talents and abilities; Reveling in the good things life has to offer; Indulging yourself; Relaxing and unwinding; Having everything you need in order to feel complete",
+      "meaningReversed": "Being smug; Satisfying yourself at the expense of others; Being selfish; Over-indulging; Avoiding work that needs to be done; Claiming achievements or skills you do not possess; Never being satisfied, no matter how much you have"
+    },
+    {
+      "name": "ten of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 10,
+      "meaningUpright": "Having more than you ever dreamed; Being deeply thankful for all you've been given; Recognizing the Hand of God in the gifts the Universe brings your way; Experiencing transcendent joy; Achieving domestic bliss",
+      "meaningReversed": "Comparing your achievements or relationships to unrealistic fantasy standards; Experiencing emotions so intense they blunt your ability to cope with reality; Feeling overwhelmed; Envying the achievements and happiness of others"
+    },
+    {
+      "name": "page of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 11,
+      "meaningUpright": "Showing your emotions freely; Throwing yourself into romance; Nursing a secret crush; Indulging in romantic fantasy; Starting a new relationship; Recalling your first love; Experiencing love for the first time; Converting to a new religion",
+      "meaningReversed": "Mistaking a crush for true love; Reading romantic intention into innocent action; Frantically trying to impress others; Indulging in overly-sweet sentimentality; Pretending to more romantic or spiritual experience than you possess"
+    },
+    {
+      "name": "knight of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 12,
+      "meaningUpright": "Being deeply committed to a cause; Giving in to strong emotions, from excitement to depression; Acting on intuition alone; Solving problems intuitively; Believing in and basing decisions on ideals instead of realities; Bringing intuition or passion to the table",
+      "meaningReversed": "Becoming a fanatic; Rejecting information that suggests your intuitions are misguided; Allowing your emotions to control you; Giving in to jealousy, confrontation, and peer pressure; Hiding or ignoring intuitive insights"
+    },
+    {
+      "name": "queen of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 13,
+      "meaningUpright": "Allowing yourself to be moved by the plight of others; Feeling strong emotions; Possessing unusual sympathy or empathy; Trusting your feelings to guide you; Calling on psychic abilities; Achieving unity with Spirit",
+      "meaningReversed": "Becoming so caught up in matters of Spirit, you become detached from the world; Allowing empathy to disable you (instead of inspire action); Using psychic abilities to wield covert influence; Wallowing in emotionalism, sentiment, or self-pity"
+    },
+    {
+      "name": "king of cups",
+      "arcana": "minor",
+      "suit": "cups",
+      "number": 14,
+      "meaningUpright": "Keeping a stiff upper lip; Being brave and clear in the face of adverse circumstances; Sharing experience as a way of comforting others; Making fair and empathetic decisions; Honoring the spirit, not just the letter, of the law",
+      "meaningReversed": "Allowing yourself to become rigid and unemotional; Making unfair decisions based on a hidden agenda; Making decisions without regard for their emotional impact on others; Abusing spiritual authority; Using emotional or spiritual leverage to exercise unhealthy control over others"
+    },
+    {
+      "name": "ace of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 1,
+      "meaningUpright": "Making objective decisions; Applying logic; Reasoning your way out of a difficult situation; Solving puzzles; Thinking things through; Emphasizing the facts; Clearing your mind; Seeking clarity",
+      "meaningReversed": "Applying ruthless or twisted logic; Gloating over your own superior intellect; Using quick thinking to deceive or confuse others; Confusing snap judgments with quick thinking; Making decisions without thinking through consequences"
+    },
+    {
+      "name": "two of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 2,
+      "meaningUpright": "Refusing to make a decision without getting the facts; Exploring both sides of an argument; Arguing passionately for what you believe in; Weighing the issues; Encouraging the open exchange of ideas; Discussing political or religious issues without getting \"hot under the collar\"",
+      "meaningReversed": "Rejecting evidence that conflicts with dearly-held beliefs; Arguing with others just for the sake of doing so; Nit-picking; Putting off a decision because you're afraid to face the consequences; Preventing others from getting the information they need to make good decisions"
+    },
+    {
+      "name": "three of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 3,
+      "meaningUpright": "Being brave enough to see things as they really are; Exercising your critical eye; Being your own best critic; Acknowledging that things don't always turn out as planned; Moving past heartbreak to embrace a painful truth",
+      "meaningReversed": "Wallowing in despair; Allowing yourself to be completely crushed by the thoughts, words, or deeds of another; Judging yourself too harshly; Holding yourself to an unrealistic standard of excellence; Wearing your heart on your sleeve while carrying a chip on your shoulder"
+    },
+    {
+      "name": "four of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 4,
+      "meaningUpright": "Thinking over your plans before putting them into action; Pausing to meditate or clear your mind; Taking time to understand someone or something before criticizing it; Resting; Occupying your thoughts with a healthy distraction",
+      "meaningReversed": "Failing to think things through; Mistaking procrastination for thoughtfulness; Adopting a point of view and refusing to reconsider your conclusions, even when presented with refuting evidence; Allowing chaos and whimsy to dominate your thoughts"
+    },
+    {
+      "name": "five of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 5,
+      "meaningUpright": "Acting in your own best interest; Choosing to stand up for yourself; Not backing down from disagreement and discord; Taking a stand; Refusing to go along with an unethical plan; Knowing when to bend the rules",
+      "meaningReversed": "Taking advantage of others; Intimidating others; Acting in an unethical manner; Picking fights; Using words to goad others into violence and irrationality; Ignoring rules you've agreed to abide by; Looking out for yourself while allowing harm to come to others; Gloating over victory"
+    },
+    {
+      "name": "six of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 6,
+      "meaningUpright": "Making the best of a bad situation; Recovering from defeat; Resetting expectations; Making allowances for unexpected circumstances; Helping others who find themselves in dire circumstances; Changing the way you see the world; Broadening your perspective through study or travel",
+      "meaningReversed": "Refusing to accept that things have changed; Playing the victim; Rejecting the idea that your actions have consequences; Applying scientific criteria to matters of faith, or confusing faith with science; Believing the whole world should be like your small corner of it"
+    },
+    {
+      "name": "seven of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 7,
+      "meaningUpright": "Refusing to do something dishonest, even when there's no chance of ever being caught; Handling a difficult situation with finesse; Pointing out assumptions; Acting ethically in public and in private; Living a life that is beyond reproach",
+      "meaningReversed": "Stealing or lying; Doing whatever you can get away with, simply because you can; Looking for a way around consequences; Justifying wicked behavior by focusing on the wickedness of others; Failing to examine your own motives and prejudices"
+    },
+    {
+      "name": "eight of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 8,
+      "meaningUpright": "Honoring limits; Respecting the rules; Deciding to go on a diet for your health's sake; Recognizing you cannot always be in control; Identifying obstacles to further progress; Refusing to think about unhealthy or unethical options; Asking for assistance",
+      "meaningReversed": "Feeling trapped; Being lost in a maze of rules and regulations; Giving in to despair; Playing the victim; Allowing others to dictate what you can and cannot do; Being rendered helpless; Having very few options; Failing to look for a way out"
+    },
+    {
+      "name": "nine of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 9,
+      "meaningUpright": "Refusing to worry about what you cannot control; Rejecting anxiety; Judging your own performance with kindness and gentleness; Using meditation to quiet a troubled mind; Confronting nightmares and fears; Drawing a conclusion and putting an issue out of your mind",
+      "meaningReversed": "Torturing yourself with regrets; Second-guessing your every move; Beating yourself up for your mistakes; Depression; Obsessing on errors and overlooked details; Refusing to handle stress in healthy ways; Ruining your ability to appreciate the present by dwelling on the past; Debating irreversible decisions"
+    },
+    {
+      "name": "ten of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 10,
+      "meaningUpright": "Seeing the signs that you've reached your limits; Paying attention to what your body is trying to tell you; Giving in to the need for rest and renewal; Acknowledging that you've hit bottom; Committing to a turnaround; Knowing the worst is over",
+      "meaningReversed": "Accepting defeat prematurely; Driving yourself to total exhaustion, especially mentally; Experiencing a mental breakdown; Obsessing on a problem to the breaking point; Giving up; Refusing to move from thought to action; Deeply unhealthy thoughts"
+    },
+    {
+      "name": "page of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 11,
+      "meaningUpright": "Pursuing a course of study; Asking good questions; Investing time in study and practice; Doing research; Making a habit of learning new things; Starting an investigation; Outlining what you need to know; Finding a mentor or teacher",
+      "meaningReversed": "Pretending to knowledge or sophistication you do not possess; Cheating on an exam; Feigning interest as a way of gaining favor; Considering only the evidence that supports conclusions you've already drawn; Rejecting the wise counsel of experienced teachers"
+    },
+    {
+      "name": "knight of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 12,
+      "meaningUpright": "Speaking your mind; Making your opinions known; Offering constructive criticism; Sharing your knowledge; Making insightful observations; Pinpointing the problem; Clarifying what others have said; Giving clear direction to others; Uncovering the truth",
+      "meaningReversed": "Stating your opinions as fact; Picking fights; Starting arguments; Using clever insults to undermine the confidence of others; Tossing reason out the window; Speaking without taking the feelings of others into account; Going on a witch hunt; Distorting evidence"
+    },
+    {
+      "name": "queen of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 13,
+      "meaningUpright": "Exercising tact or using diplomacy; Defusing a tense situation; Knowing what to say and how to say it; Making others feel comfortable and confident; Bringing out the best in everyone; Having a way with words; Telling jokes; Possessing a knack for music, math, art, or science",
+      "meaningReversed": "Knowing exactly what to say to destroy another person; Withholding critical information; Using a barbed tongue to upset others; Employing sarcasm; Mimicking others unkindly; Making light of the less fortunate; Being disrespectful; Failing to use the talent you've been given"
+    },
+    {
+      "name": "king of swords",
+      "arcana": "minor",
+      "suit": "swords",
+      "number": 14,
+      "meaningUpright": "Expressing yourself with firmness and authority; Rendering a final decision; Consulting an expert; Calling in advisors and consultants; Coming to a final conclusion; Reaching a beneficial agreement based on sound information",
+      "meaningReversed": "Insisting on having the last word; Flaunting your intellectual capability; Talking \"over the heads\" of others; Waffling on an important decision; Constantly changing your mind; Refusing to make choices that are in your own best interest; Wishing in vain you could take back what's been said"
+    },
+    {
+      "name": "ace of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 1,
+      "meaningUpright": "Outlining a plan for achieving prosperity; Becoming aware of opportunities to improve income or health; Realizing you have everything you need; Appreciating everything the Universe has given you; Receiving the perfect gift at the perfect time",
+      "meaningReversed": "Indulging in relentless consumerism; Wanting more, no matter how much you have; Obsessing on your account balance; Suffering from hypochondria; Consuming blessings without expressing gratitude; Taking what you want without concern for the needs of others"
+    },
+    {
+      "name": "two of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 2,
+      "meaningUpright": "Weighing options; Comparing prices; Determining the value of one option over another; Juggling resources to make ends meet; Making difficult choices based on what's best for your body or your bankbook; Looking at the bottom line; Asking for a second opinion on health issues",
+      "meaningReversed": "Engaging in endless price comparison; Putting off a buying decision for fear of finding a slightly better value later on; Buying something without regard for value; Breaking your budget with unnecessary expenses; Engaging in behavior with no regard for how your body or bankbook will be impacted"
+    },
+    {
+      "name": "three of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 3,
+      "meaningUpright": "Finishing a project; Setting and meeting standards; Performing according to specifications; Making something others value; Creating something new; Doing your part in a group project; Delivering exactly what others have asked for",
+      "meaningReversed": "Pandering to the tastes of others; Failing to deliver what you've promised; Not delivering your best work unless closely supervised; Ignoring or breaking agreements with those who have invested in you; Refusing to do your part; Failing to abide by a clearly-outlined agreement with yourself or others"
+    },
+    {
+      "name": "four of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 4,
+      "meaningUpright": "Saving for a rainy day; Fasting as part of a spiritual practice; Dieting in an effort to improve your body; Abstaining from sex as a way of honoring a spiritual tradition or personal promise; Being financially conservative; Establishing a trust fund; Opening a savings account",
+      "meaningReversed": "Being stingy; Refusing to spend money that needs to be spent; Withholding sex from your partner; Taking care of your own needs exclusively, without regard for the needs of others; Spending a dollar to save a penny; Failing to be a good manager of the blessings you've been given"
+    },
+    {
+      "name": "five of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 5,
+      "meaningUpright": "Recognizing your needs and taking action to fulfill them; Doing as much as you can do with what little you have; Admitting you need help; Embracing the aid that comes your way; Focusing on what you have versus what you don't; Looking for the light at the end of the tunnel",
+      "meaningReversed": "Exaggerating your financial or physical needs; Adopting a poverty mentality; Refusing to support yourself; Refusing offers of support; Playing the martyr; Turning down opportunities to improve your health or finances; Wallowing in misery"
+    },
+    {
+      "name": "six of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 6,
+      "meaningUpright": "Giving time, money, or effort to a charity; Taking part in a group effort; Lending your resources to others without expecting anything in return; Making sure everyone is treated equally; Working together toward a common goal; Redistributing wealth, time, or attention; Tithing; Sharing credit for your success",
+      "meaningReversed": "Making a loan as a means of gaining control over someone; Using charitable acts to draw attention to yourself; Dividing work or resources unfairly; Failing to do your part in a group effort; Ignoring obligations and commitments"
+    },
+    {
+      "name": "seven of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 7,
+      "meaningUpright": "Measuring progress toward your goal; Looking at results with an eye toward improving performance; Asking, \"How happy am I?\"; Coming up with ideas for improving your health or prosperity; Deciding it's time for a change; Expressing an honest opinion",
+      "meaningReversed": "Becoming distracted by melancholy thoughts; Longing for \"the good old days\"; Beating yourself up over lost opportunities; Judging your own work harshly; Holding others to inappropriate standards; Refusing to take part in a project, then whining about the quality of the outcome"
+    },
+    {
+      "name": "eight of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 8,
+      "meaningUpright": "Doing your best; Bringing enthusiasm and zeal to your work; Making an effort to be the best you can be; Finding the work that is right for you; Taking care of the small details; Becoming a finely skilled craftsperson; Building something with your hands; Making a handmade gift",
+      "meaningReversed": "Working yourself to death; Doing a half-hearted or sloppy job; Continuing in a job you hate; Buying thoughtless gifts; Producing work with shoddy craftsmanship; Rushing through your work; Rejecting opportunities to learn more about your craft"
+    },
+    {
+      "name": "nine of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 9,
+      "meaningUpright": "Investing time in learning or teaching a difficult task; Restraining yourself from physical or financial extremes; Making sacrifices as a way of achieving larger goals; Breaking a complex task down into simple steps; Wanting what you have; Knowing the difference between needs and wants",
+      "meaningReversed": "Being assigned to a task without being trained to perform it; Pursuing a position for which you are not qualified; Disregarding requirements; Refusing to dedicate adequate time or attention when learning about something or someone new; Always craving more"
+    },
+    {
+      "name": "ten of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 10,
+      "meaningUpright": "Celebrating your physical and financial blessings; Realizing how lucky or how blessed you are; Being satisfied with your physical and financial achievements; Taking best advantage of \"times of plenty\"; Enjoying a feast; Showering friends or family with gifts",
+      "meaningReversed": "Spending all of your money on extravagant gifts and possessions; Trying too hard to impress others with your wealth or physique; Giving an inappropriately expensive gift as a means of currying favor; Obsessing on matters of weight, health, or finance; Always asking, \"What's in it for me?\""
+    },
+    {
+      "name": "page of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 11,
+      "meaningUpright": "Learning the value of a dollar; Starting a savings plan; Taking the first steps toward getting out of debt; Learning new physical tasks; Discovering your sexuality; Launching a diet, a weight-lifting program, or a health-related effort; Learning by doing",
+      "meaningReversed": "Trying to appear healthier or wealthier than you really are; Spending money carelessly; Living strictly for today, with no thought of tomorrow; Possessing immature attitudes toward sex and sexuality; Using wealth or beauty as an excuse for not having to learn and grow"
+    },
+    {
+      "name": "knight of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 12,
+      "meaningUpright": "Spending money wisely; Saving for a rainy day; Paying close attention to physical or financial details; Knowing where every dollar goes; Having safe sex; Preferring facts to \"good feelings\"; Finding creative ways to \"make do\" with resources on hand; Completing a new invention",
+      "meaningReversed": "Throwing caution to the four winds; Spending without regard for consequence; Spending on luxury when necessities are lacking; Escaping stress by spending money; Obsessing on tiny physical or financial details; Perpetually chasing after some new bauble; Copying another's work and claiming it as your own"
+    },
+    {
+      "name": "queen of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 13,
+      "meaningUpright": "Appreciating fine food, fine wine, beautiful art, beautiful bodies, or any of the better things in life; Reveling in healthy sexuality; Treating yourself; Splurging on the occasional \"nice to have\" item; Rewarding someone with compensation above and beyond expectations; Having it all",
+      "meaningReversed": "Indulging in gluttony or greediness; Becoming insatiable; Blunting the impact of treats by indulging in them too often; Providing physical comfort without providing for emotional needs; Allowing a feeling of entitlement to distort your gratitude for what you're given"
+    },
+    {
+      "name": "king of coins",
+      "arcana": "minor",
+      "suit": "coins",
+      "number": 14,
+      "meaningUpright": "Becoming debt-free; Having more than enough to get by; Making contributions to a savings plan; Taking a new job with an eye toward advancing your career; Buying life or health insurance; Being confident in the bedroom; Taking on the role of enforcer when called upon to do so",
+      "meaningReversed": "Becoming so conservative you resist all change on principle alone; Ignoring innovations in the name of preserving tradition; Being smug or cocky; Becoming ruthlessly dedicated to profit or pleasure; Being sexually selfish; Bossing others around, especially when you're not empowered to do so"
+    }
+  ]
+}

--- a/src/main/scala/InputForm.scala
+++ b/src/main/scala/InputForm.scala
@@ -10,7 +10,7 @@ object InputForm:
 
     div(
       h2("Question"),
-      textarea(
+      textArea(
         placeholder := "Enter your question",
         onInput.mapToValue --> questionVar
       ),

--- a/src/main/scala/model/TarotModels.scala
+++ b/src/main/scala/model/TarotModels.scala
@@ -1,0 +1,25 @@
+package model
+
+case class TarotCard(
+  name: String,
+  arcana: String, // "major" or "minor"
+  suit: Option[String],
+  number: Option[Int],
+  meaningUpright: String,
+  meaningReversed: String
+)
+
+case class DrawnCard(
+  card: TarotCard,
+  orientation: String // "正位置" or "逆位置"
+)
+
+case class AppState(
+  userInput: String,
+  spread: Int,
+  temperature: Double,
+  drawMode: String, // "random" | "mixed" | "llm"
+  selectedCards: List[DrawnCard],
+  interpretation: String,
+  tone: String // "logical" | "poetic" | "casual" | "fortune"
+)


### PR DESCRIPTION
## Summary
- expanded tarot card data to include all 78 cards

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_68468a5d23e8832fa89054c1529ed848